### PR TITLE
Schedule: automatically schedule commands

### DIFF
--- a/src/SeatConnectorServiceProvider.php
+++ b/src/SeatConnectorServiceProvider.php
@@ -30,6 +30,7 @@ use Seat\Web\Events\UserRoleRemoved;
 use Seat\Web\Models\Squads\SquadMember;
 use Warlof\Seat\Connector\Commands\DriverApplyPolicies;
 use Warlof\Seat\Connector\Commands\DriverUpdateSets;
+use Warlof\Seat\Connector\Database\Seeders\ScheduleSeeder;
 use Warlof\Seat\Connector\Events\EventLogger;
 use Warlof\Seat\Connector\Listeners\LoggerListener;
 use Warlof\Seat\Connector\Listeners\UserRoleAddedListener;
@@ -65,6 +66,8 @@ class SeatConnectorServiceProvider extends AbstractSeatPlugin
      */
     public function register(): void
     {
+        $this->registerDatabaseSeeders(ScheduleSeeder::class);
+
         $this->mergeConfigFrom(__DIR__ . '/Config/package.sidebar.php', 'package.sidebar');
         $this->mergeConfigFrom(__DIR__ . '/Config/seat-connector.config.php', 'seat-connector.config');
 

--- a/src/database/seeders/ScheduleSeeder.php
+++ b/src/database/seeders/ScheduleSeeder.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Warlof\Seat\Connector\Database\Seeders;
+
+use Seat\Services\Seeding\AbstractScheduleSeeder;
+
+class ScheduleSeeder extends AbstractScheduleSeeder
+{
+
+    /**
+     * Returns an array of schedules that should be seeded whenever the stack boots up.
+     *
+     * @return array
+     */
+    public function getSchedules(): array
+    {
+        return [
+            [   // Sync sets for all drivers | Once a day
+                'command' => 'seat-connector:sync:sets',
+                'expression' => '0 0 * * *',
+                'allow_overlap' => false,
+                'allow_maintenance' => false,
+                'ping_before' => null,
+                'ping_after' => null,
+            ],
+            [   // Apply policies | Every hour
+                'command' => 'seat-connector:apply:policies',
+                'expression' => '0 * * * *',
+                'allow_overlap' => false,
+                'allow_maintenance' => false,
+                'ping_before' => null,
+                'ping_after' => null,
+            ]
+        ];
+    }
+
+    /**
+     * Returns a list of commands to remove from the schedule.
+     *
+     * @return array
+     */
+    public function getDeprecatedSchedules(): array
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
Currently, every user has to manually add the seat-connector commands to the schedule. This causes unnecessary friction when this can be automated.

The exact interval of the schedules are up for debate, I've just used some values that appear reasonable.