### PR TITLE
custom nick names

### DIFF
--- a/src/Commands/DriverApplyPolicies.php
+++ b/src/Commands/DriverApplyPolicies.php
@@ -35,7 +35,8 @@ class DriverApplyPolicies extends Command
      */
     protected $signature = 'seat-connector:apply:policies
                             {--driver=* : The specific driver name for which you want apply policy}
-                            {--terminator : Revoke all Sets}';
+                            {--terminator : Revoke all Sets}
+                            {--sync : Execute without sending the job through the queue, useful for debugging}';
 
     /**
      * @var string
@@ -51,6 +52,7 @@ class DriverApplyPolicies extends Command
         $drivers_parameter = $this->option('driver');
         $drivers = collect(array_keys(config('seat-connector.drivers')));
         $terminator = $this->option('terminator') ?: false;
+        $sync = $this->option('sync') ?: false;
 
         if ($drivers->isEmpty()) {
             throw new MissingDriverException('No SeAT Connector drivers has been found.' . PHP_EOL .
@@ -80,8 +82,12 @@ class DriverApplyPolicies extends Command
                 continue;
             }
 
-            dispatch(new \Warlof\Seat\Connector\Jobs\DriverApplyPolicies($driver, $terminator))->onQueue('high');
-            $this->info(sprintf('A new Policy job has been enqueue for driver %s', $driver));
+            if(!$sync){
+                dispatch(new \Warlof\Seat\Connector\Jobs\DriverApplyPolicies($driver, $terminator))->onQueue('high');
+                $this->info(sprintf('A new Policy job has been enqueue for driver %s', $driver));
+            } else {
+                \Warlof\Seat\Connector\Jobs\DriverApplyPolicies::dispatchSync($driver, $terminator);
+            }
         }
     }
 }

--- a/src/Http/Controllers/UsersController.php
+++ b/src/Http/Controllers/UsersController.php
@@ -21,6 +21,7 @@
 
 namespace Warlof\Seat\Connector\Http\Controllers;
 
+use Illuminate\Http\Request;
 use Illuminate\Support\Arr;
 use Seat\Web\Http\Controllers\Controller;
 use Warlof\Seat\Connector\Exceptions\DriverException;
@@ -98,5 +99,42 @@ class UsersController extends Controller
 
         return redirect()->back()
             ->with('success', 'Identity has been successfully dropped.');
+    }
+
+    public function edit(Request $request)
+    {
+        $request->validate([
+            'user_id' => 'required|integer',
+            'name_override' => 'nullable|string',
+            'name_override_enable'=>'nullable'
+        ]);
+
+        // attempt to retrieve requested identity
+        $identity = User::find($request->user_id);
+
+        if (is_null($identity)) {
+            return redirect()->back()
+                ->with('error', 'An error occurred while attempting to edit a user mapping. User not found.');
+        }
+
+        $name_override_enabled = $request->name_override_enable !== null; // checkboxes are annoying
+        $name_override = $request->name_override;
+        $name_override_valid = $name_override !== null && strlen($name_override)>0;
+
+        if($name_override_enabled && !$name_override_valid) {
+            return redirect()->back()
+                ->with('error', 'An error occurred while attempting to edit a user mapping: Invalid name override.');
+        }
+
+        if($name_override_enabled) {
+            $identity->name_override = $name_override;
+        } else {
+            $identity->name_override = null;
+        }
+
+        $identity->save();
+
+        return redirect()->back()
+            ->with('success', 'Successfully updated name override!');
     }
 }

--- a/src/Http/DataTables/UserMappingDataTable.php
+++ b/src/Http/DataTables/UserMappingDataTable.php
@@ -38,7 +38,7 @@ class UserMappingDataTable extends DataTable
     {
         return datatables()
             ->eloquent($this->applyScopes($this->query()))
-            ->editColumn('action', fn($row) => view('seat-connector::users.partials.delete', ['row' => $row]))
+            ->editColumn('action', fn($row) => view('seat-connector::users.partials.actions-button', ['row' => $row]))
             ->toJson();
     }
 
@@ -48,7 +48,7 @@ class UserMappingDataTable extends DataTable
     public function query(): \Illuminate\Database\Eloquent\Builder|\Illuminate\Database\Query\Builder
     {
         return User::with('user')
-            ->select('seat_connector_users.id', 'connector_id', 'connector_name', 'user_id');
+            ->select('seat_connector_users.id', 'connector_id', 'connector_name', 'name_override', 'user_id');
     }
 
     /**
@@ -89,6 +89,10 @@ class UserMappingDataTable extends DataTable
             [
                 'data'  => 'connector_name',
                 'title' => trans('seat-connector::seat.connector_name'),
+            ],
+            [
+                'data'  => 'name_override',
+                'title' => trans('seat-connector::seat.name_override'),
             ],
         ];
     }

--- a/src/Http/routes.php
+++ b/src/Http/routes.php
@@ -58,6 +58,10 @@ Route::group([
                 ->name('seat-connector.users.destroy')
                 ->uses('UsersController@destroy');
 
+            Route::post('/users/edit')
+                ->name('seat-connector.users.edit')
+                ->uses('UsersController@edit');
+
             Route::get('/access')
                 ->name('seat-connector.acl')
                 ->uses('AccessController@index');

--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -28,6 +28,13 @@ use Seat\Web\Models\User as SeatUser;
 
 /**
  * Class User.
+ *
+ * @property string connector_type
+ * @property int connector_id
+ * @property string connector_name
+ * @property string name_override
+ * @property int user_id
+ * @property int unique_id
  */
 class User extends Model
 {
@@ -40,7 +47,7 @@ class User extends Model
      * @var array
      */
     protected $fillable = [
-        'connector_type', 'connector_id', 'connector_name', 'user_id', 'unique_id',
+        'connector_type', 'connector_id', 'connector_name', 'name_override', 'user_id', 'unique_id',
     ];
 
     /**
@@ -209,6 +216,10 @@ class User extends Model
      */
     public function buildConnectorNickname(): string
     {
+        if($this->name_override != null && strlen($this->name_override)>0) {
+            return $this->name_override;
+        }
+
         $character = $this->user->main_character;
 
         if (is_null($character->name)) {

--- a/src/database/migrations/2025_07_03_103657_add_name_overrides.php
+++ b/src/database/migrations/2025_07_03_103657_add_name_overrides.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of seat-connector and provides user synchronization between both SeAT and third party platform
+ *
+ * Copyright (C) 2019 to 2022 Loïc Leuilliot <loic.leuilliot@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Class CleanActionSeat400.
+ */
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up(): void
+    {
+        Schema::table('seat_connector_users', function (Blueprint $table): void {
+            $table->string('name_override')->nullable()->after('connector_name');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down(): void
+    {
+        Schema::table('seat_connector_users', function (Blueprint $table): void {
+            $table->dropColumn('name_override');
+        });
+    }
+};

--- a/src/resources/lang/en/seat.php
+++ b/src/resources/lang/en/seat.php
@@ -22,11 +22,14 @@
 return [
     'settings'           => 'Settings',
     'save'               => 'Save',
+    'close'              => 'Close',
 
     'toolbox'            => 'Toolbox',
     'access_management'  => 'Access Management',
     'user_mapping'       => 'User Mapping',
     'journal'            => 'Journal',
+
+    'edit_user_mapping'  => 'Edit User Mapping',
 
     'all_filter'         => 'All Filters',
     'public_filter'      => 'Public Filters',
@@ -55,6 +58,11 @@ return [
     'character_name'     => 'Character Name',
     'connector_id'       => 'Connector ID',
     'connector_name'     => 'Connector Name',
+    'name_override'      => 'Name Override',
+
+    'enter_custom_name'  => 'Enter a custom name',
+    'enable_name_override' => 'Enable name override',
+
 
     'identities'         => 'Identity|Identities',
 ];

--- a/src/resources/views/users/list.blade.php
+++ b/src/resources/views/users/list.blade.php
@@ -36,6 +36,8 @@
         </div>
       </div>
     </div>
+
+    @include('seat-connector::users.partials.edit-modal')
   @endif
 @stop
 

--- a/src/resources/views/users/partials/actions-button.blade.php
+++ b/src/resources/views/users/partials/actions-button.blade.php
@@ -1,0 +1,10 @@
+<div class="row">
+  <button type="button" class="btn btn-sm btn-primary mr-1" data-toggle="modal" data-target="#userModal" data-name-override="{{ $row->name_override }}">
+    Edit
+  </button>
+  <form method="post" action="{{ route('seat-connector.users.destroy', ['id' => $row->id]) }}">
+    {!! csrf_field() !!}
+    {!! method_field('DELETE') !!}
+    <button type="submit" class="btn btn-sm btn-danger">Remove</button>
+  </form>
+</div>

--- a/src/resources/views/users/partials/actions-button.blade.php
+++ b/src/resources/views/users/partials/actions-button.blade.php
@@ -1,5 +1,5 @@
 <div class="row">
-  <button type="button" class="btn btn-sm btn-primary mr-1" data-toggle="modal" data-target="#userModal" data-name-override="{{ $row->name_override }}">
+  <button type="button" class="btn btn-sm btn-primary mr-1" data-toggle="modal" data-target="#userModal" data-user-id="{{ $row->id }}" data-name-override="{{ $row->name_override }}">
     Edit
   </button>
   <form method="post" action="{{ route('seat-connector.users.destroy', ['id' => $row->id]) }}">

--- a/src/resources/views/users/partials/delete.blade.php
+++ b/src/resources/views/users/partials/delete.blade.php
@@ -1,5 +1,0 @@
-<form method="post" action="{{ route('seat-connector.users.destroy', ['id' => $row->id]) }}">
-  {!! csrf_field() !!}
-  {!! method_field('DELETE') !!}
-  <button type="submit" class="btn btn-sm btn-danger">Remove</button>
-</form>

--- a/src/resources/views/users/partials/edit-modal.blade.php
+++ b/src/resources/views/users/partials/edit-modal.blade.php
@@ -8,18 +8,22 @@
                 </button>
             </div>
             <div class="modal-body">
-                <div class="form-group">
-                    <label>{{ trans('seat-connector::seat.name_override') }}</label>
-                    <input type="text" class="form-control mb-1" name="name-override" placeholder="{{ trans('seat-connector::seat.enter_custom_name') }}">
-                    <div class="form-check">
-                        <input class="form-check-input" type="checkbox" name="name-override-enable" id="name-override-enable">
-                        <label class="form-check-label" for="name-override-enable">
-                            {{ trans('seat-connector::seat.enable_name_override') }}
-                        </label>
+                <form action="{{ route("seat-connector.users.edit") }}" method="POST">
+                    @csrf()
+                    <input type="hidden" name="user_id">
+                    <div class="form-group">
+                        <label>{{ trans('seat-connector::seat.name_override') }}</label>
+                        <input type="text" class="form-control mb-1" name="name_override" placeholder="{{ trans('seat-connector::seat.enter_custom_name') }}">
+                        <div class="form-check">
+                            <input class="form-check-input" type="checkbox" name="name_override_enable" id="name-override-enable">
+                            <label class="form-check-label" for="name-override-enable">
+                                {{ trans('seat-connector::seat.enable_name_override') }}
+                            </label>
+                        </div>
                     </div>
-                </div>
-                <button type="button" class="btn btn-primary">{{ trans('seat-connector::seat.save') }}</button>
-                <button type="button" class="btn btn-secondary" data-dismiss="modal">{{ trans('seat-connector::seat.close') }}</button>
+                    <button type="submit" class="btn btn-primary">{{ trans('seat-connector::seat.save') }}</button>
+                    <button type="button" class="btn btn-secondary" data-dismiss="modal">{{ trans('seat-connector::seat.close') }}</button>
+                </form>
             </div>
         </div>
     </div>
@@ -31,11 +35,14 @@
             const button = $(event.relatedTarget) // Button that triggered the modal
             const modal = $(this)
 
+            const user_id = button.data('user-id')
+            modal.find('.modal-body input[name="user_id"]').val(user_id)
+
             const name_override = button.data('name-override')
-            modal.find('.modal-body input[name="name-override"]').val(name_override)
+            modal.find('.modal-body input[name="name_override"]').val(name_override)
 
             const name_override_enabled = name_override !== ""
-            modal.find('.modal-body input[name="name-override-enable"]').prop( "checked", name_override_enabled)
+            modal.find('.modal-body input[name="name_override_enable"]').prop( "checked", name_override_enabled)
 
         })
     </script>

--- a/src/resources/views/users/partials/edit-modal.blade.php
+++ b/src/resources/views/users/partials/edit-modal.blade.php
@@ -12,8 +12,8 @@
                     @csrf()
                     <input type="hidden" name="user_id">
                     <div class="form-group">
-                        <label>{{ trans('seat-connector::seat.name_override') }}</label>
-                        <input type="text" class="form-control mb-1" name="name_override" placeholder="{{ trans('seat-connector::seat.enter_custom_name') }}">
+                        <label for="name-override">{{ trans('seat-connector::seat.name_override') }}</label>
+                        <input type="text" class="form-control mb-1" id="name-override" name="name_override" placeholder="{{ trans('seat-connector::seat.enter_custom_name') }}">
                         <div class="form-check">
                             <input class="form-check-input" type="checkbox" name="name_override_enable" id="name-override-enable">
                             <label class="form-check-label" for="name-override-enable">
@@ -43,7 +43,12 @@
 
             const name_override_enabled = name_override !== ""
             modal.find('.modal-body input[name="name_override_enable"]').prop( "checked", name_override_enabled)
-
+        })
+        
+        $('#name-override').on('input',function (e) {
+            const modal = $('#userModal')
+            const has_override_name = $(this).val().length > 0
+            modal.find('.modal-body input[name="name_override_enable"]').prop( "checked", has_override_name)
         })
     </script>
 @endpush

--- a/src/resources/views/users/partials/edit-modal.blade.php
+++ b/src/resources/views/users/partials/edit-modal.blade.php
@@ -1,0 +1,42 @@
+<div class="modal" tabindex="-1" id="userModal">
+    <div class="modal-dialog modal-dialog-centered">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">{{ trans('seat-connector::seat.edit_user_mapping') }}</h5>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+            <div class="modal-body">
+                <div class="form-group">
+                    <label>{{ trans('seat-connector::seat.name_override') }}</label>
+                    <input type="text" class="form-control mb-1" name="name-override" placeholder="{{ trans('seat-connector::seat.enter_custom_name') }}">
+                    <div class="form-check">
+                        <input class="form-check-input" type="checkbox" name="name-override-enable" id="name-override-enable">
+                        <label class="form-check-label" for="name-override-enable">
+                            {{ trans('seat-connector::seat.enable_name_override') }}
+                        </label>
+                    </div>
+                </div>
+                <button type="button" class="btn btn-primary">{{ trans('seat-connector::seat.save') }}</button>
+                <button type="button" class="btn btn-secondary" data-dismiss="modal">{{ trans('seat-connector::seat.close') }}</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+@push('javascript')
+    <script>
+        $('#userModal').on('show.bs.modal', function (event) {
+            const button = $(event.relatedTarget) // Button that triggered the modal
+            const modal = $(this)
+
+            const name_override = button.data('name-override')
+            modal.find('.modal-body input[name="name-override"]').val(name_override)
+
+            const name_override_enabled = name_override !== ""
+            modal.find('.modal-body input[name="name-override-enable"]').prop( "checked", name_override_enabled)
+
+        })
+    </script>
+@endpush


### PR DESCRIPTION
With this PR, administrators can set custom nicknames that override a user's eve character name. We use this for members that we call differently than what their eve character is called (for example, recursivetree -> tree). 

These name overrides can be managed from the user mapping screen:
<img width="1196" alt="Bildschirmfoto 2025-07-03 um 11 43 13" src="https://github.com/user-attachments/assets/73b488c1-bfeb-4933-931f-7cf0e77970ff" />

<img width="626" alt="Bildschirmfoto 2025-07-03 um 11 44 24" src="https://github.com/user-attachments/assets/2e67d77b-3aaa-49c3-80e4-5baa6d7a1972" />
