### PR TITLE
fix: autoload seeder to avoid crash

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
   ],
   "autoload": {
     "psr-4": {
-      "Warlof\\Seat\\Connector\\": "src/"
+      "Warlof\\Seat\\Connector\\": "src/",
+      "Warlof\\Seat\\Connector\\Database\\Seeders\\": "src/database/seeders/"
     }
   },
   "require": {


### PR DESCRIPTION
While installing the latest update, I got a crash because the seeder introduced in https://github.com/zenobio93/seat-connector/pull/2 wasn't being autoloaded.

Sorry, this is my mistake. I forgot that it works fine without the autoload on dev installs, but for composer installs you have to add it to the composer.json.