### PR TITLE
fix: update wrong name in database even if connector name is correct

### DIFF
--- a/src/Traits/ConnectorPolicyManagement.php
+++ b/src/Traits/ConnectorPolicyManagement.php
@@ -58,18 +58,17 @@ trait ConnectorPolicyManagement
     {
         $new_nickname = $profile->buildConnectorNickname();
 
-        // identity nick is already up-to-date - we have nothing to do here
-        if ($identity->getName() === $new_nickname) {
-            return;
+        if ($identity->getName() !== $new_nickname) {
+            if ($identity->setName($new_nickname)) {
+                event(new EventLogger($profile->connector_type, 'info', 'policy',
+                    sprintf('Nickname from the user %s (%s) from group %d has been updated.',
+                        '', $identity->getName(), $profile->user->id)));
+            }
         }
 
-        if ($identity->setName($new_nickname)) {
+        if($identity->getName() !== $profile->connector_name) {
             $profile->connector_name = $identity->getName();
             $profile->save();
-
-            event(new EventLogger($profile->connector_type, 'info', 'policy',
-                sprintf('Nickname from the user %s (%s) from group %d has been updated.',
-                    '', $identity->getName(), $profile->user->id)));
         }
     }
 


### PR DESCRIPTION
When a user already has the correct name when he registers using discord, the user interface shows the wrong name under User Mapping->Connector Name. 

The connector name on the UI is from the `seat_connector_users` table. 

The bug happens because currently we only update the name in the database when we rename a user. But since the user already has the correct name, we never execute the name update logic and therefore also don't store the name in the database.

With this change, we treat updating the name on discord and updating the name in the database as two separate things that both independently execute when needed.