### PR TITLE
Update UserResource.php

### DIFF
--- a/src/Http/Resources/UserResource.php
+++ b/src/Http/Resources/UserResource.php
@@ -75,10 +75,10 @@ class UserResource extends JsonResource
     public function toArray($request)
     {
         return [
-            'user_id'        => $this->user_id,
-            'connector_type' => $this->connector_type,
-            'connector_id'   => $this->connector_id,
-            'connector_name' => $this->connector_name,
+            'user_id'        => $this->resource->user_id,
+            'connector_type' => $this->resource->connector_type,
+            'connector_id'   => $this->resource->connector_id,
+            'connector_name' => $this->resource->connector_name,
         ];
     }
 }


### PR DESCRIPTION
Fix the incorrect structure for API response
Before this fix, it returns null
```
    {
      "user_id": null,
      "connector_type": null,
      "connector_id": null,
      "connector_name": null
    },
```